### PR TITLE
fix: Landing flex, banner image sizing, audio track width

### DIFF
--- a/src/components/landing/Landing.css
+++ b/src/components/landing/Landing.css
@@ -1,6 +1,7 @@
 .landing-container {
   background-color: #71DDE9;
   height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -14,6 +15,7 @@
   white-space: pre-wrap;
   padding: 1.5rem;
   min-height: 16rem;
+  max-width: 30em;
 }
 
 /* Cursor */
@@ -56,7 +58,9 @@
   width: 100%;
 }
 
-@media screen and (min-width: 640px) {
+@media screen
+  and (min-width: 640px)
+  and (orientation: landscape) {
   .landing-container {
     flex-direction: row-reverse;
     justify-content: left;

--- a/src/components/landing/Landing.css
+++ b/src/components/landing/Landing.css
@@ -63,7 +63,7 @@
   and (orientation: landscape) {
   .landing-container {
     flex-direction: row-reverse;
-    justify-content: left;
+    justify-content: flex-end;
   }
 
   #landing-headshot {

--- a/src/components/shells/BannerShell.css
+++ b/src/components/shells/BannerShell.css
@@ -23,14 +23,15 @@
 }
 
 .banner-shell-content-flex {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-  }
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
 
 .banner-shell-content {
   padding: 0 1rem;
   max-width: 32rem;
+  flex-basis: 90%;
 }
 
 .header {

--- a/src/components/shells/BannerShell.css
+++ b/src/components/shells/BannerShell.css
@@ -58,6 +58,7 @@
 
   .banner {
     height: 100%;
+    width: 50vw;
     margin-bottom: 0;
   }
 }

--- a/src/components/shells/BannerShell.jsx
+++ b/src/components/shells/BannerShell.jsx
@@ -15,7 +15,7 @@ function BannerShell({ bannerSrc, children, srcMap, titleText }) {
           <img
             src={bannerSrc}
             srcSet={bannerSrcset}
-            sizes="100vw"
+            sizes="(min-width: 760px) 50vw, 100vw"
             className="banner"
           />
           <div className="banner-shell-content-flex">

--- a/src/components/shells/ImageLink.jsx
+++ b/src/components/shells/ImageLink.jsx
@@ -11,7 +11,7 @@ function ImageLink({ imageSrcmap, imageUrl, link, title }) {
       <img
         src={imageUrl}
         srcSet={generateSrcset(imageSrcmap)}
-        sizes="100vw"
+        sizes="(min-width: 760px) 50vw, 100vw"
       />
       <h3>{title}</h3>
     </div>


### PR DESCRIPTION
Fixes landing page flex to keep text left-aligned.  Adds `50vw` sizing to banner images in desktop media query.  BannerShell content now set to flex-basis of 90%, ensuring audio track players have same width across site regardless of title length.