### PR TITLE
fix: Remove scrollbars in BannerShell content

### DIFF
--- a/src/components/music/Musicals.jsx
+++ b/src/components/music/Musicals.jsx
@@ -7,34 +7,34 @@ import generateSrcmap from '../../utils/srcmap';
 // Import images
 import { musicalBanners } from './Musical';
 
-function Musicals() {
-  const musicals = [
-    {
-      "title": "Reprise",
-      "id": "reprise"
-    },
-    {
-      "title": "Super Iron Cooking Chef",
-      "id": "super-iron-cooking-chef"
-    },
-    {
-      "title": "Mirror, Mirror",
-      "id": "mirror-mirror"
-    },
-    {
-      "title": "2084",
-      "id": "2084"
-    },
-    {
-      "title": "Emerald City",
-      "id": "emerald-city"
-    },
-    {
-      "title": "Day One: A Sherlock Story",
-      "id": "day-one-a-sherlock-story"
-    }
-  ];
+const musicals = [
+  {
+    "title": "Reprise",
+    "id": "reprise"
+  },
+  {
+    "title": "Super Iron Cooking Chef",
+    "id": "super-iron-cooking-chef"
+  },
+  {
+    "title": "Mirror, Mirror",
+    "id": "mirror-mirror"
+  },
+  {
+    "title": "2084",
+    "id": "2084"
+  },
+  {
+    "title": "Emerald City",
+    "id": "emerald-city"
+  },
+  {
+    "title": "Day One: A Sherlock Story",
+    "id": "day-one-a-sherlock-story"
+  }
+];
 
+function Musicals() {
   return (
     <div className="musicals-wrapper">
       <div className="header">

--- a/src/components/shells/BannerShell.css
+++ b/src/components/shells/BannerShell.css
@@ -4,7 +4,8 @@
 }
 
 .banner-shell-content-wrapper {
-  overflow: scroll;
+  height: 100%;
+  width: 100%;
 }
 
 .shell-title {


### PR DESCRIPTION
Removes `overflow: scroll;` for banner-shell-content-wrapper.  Overflow is unnecessary, as div expands to include content, and included unnecessary space on bottom and right of div.

Also includes minor refactor to move Musicals const out of component.