### PR TITLE
fix: Webkit track styling, play button styling, Source Code Pro for all browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,700;1,400&family=Source+Code+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Travis Frank</title>
   </head>

--- a/src/components/shells/AudioPlayer.jsx
+++ b/src/components/shells/AudioPlayer.jsx
@@ -84,6 +84,7 @@ class AudioPlayer extends React.Component {
             onMouseDown={this.handleSeekMouseDown}
             onChange={this.handleSeekChange}
             onMouseUp={this.handleSeekMouseUp}
+            style={{'--min': 0, '--max': 0.999999, '--val': this.state.played}}
           />
           <div className="tune-time">
             <time dateTime={`P${Math.round(this.state.duration * this.state.played)}S`}>

--- a/src/components/shells/AudioPlayer.scss
+++ b/src/components/shells/AudioPlayer.scss
@@ -10,8 +10,9 @@
   border: 0;
   background: transparent;
   box-sizing: border-box;
-  width: 0;
-  height: 1.2em;
+  width: 1.2em;
+  height: 1.4em;
+  padding: 0;
 
   border-color: transparent transparent transparent #ccc;
   transition: 100ms all ease;
@@ -19,7 +20,7 @@
 
   // play state
   border-style: solid;
-  border-width: 0.6em 0 0.6em 1.2em;
+  border-width: 0.7em 0 0.7em 1.2em;
 
   &.paused {
     border-style: double;

--- a/src/components/shells/AudioPlayer.scss
+++ b/src/components/shells/AudioPlayer.scss
@@ -35,7 +35,7 @@
 
 $track-w: 100%;
 $track-h: .25em;
-$thumb-d: 1.5em;
+$thumb-d: 0em;
 $track-c: #ccc;
 $filll-c: #a9a9a9;
 
@@ -48,10 +48,8 @@ $filll-c: #a9a9a9;
   background: $track-c;
 
   @if $fill == 1 {
-    & {
-      background: linear-gradient($filll-c, $filll-c)
-      0 / var(--sx) 100% no-repeat $track-c;
-    }
+    background: linear-gradient($filll-c, $filll-c)
+    0 / var(--sx) 100% no-repeat $track-c;
   }
 }
 

--- a/src/components/shells/AudioPlayer.scss
+++ b/src/components/shells/AudioPlayer.scss
@@ -48,9 +48,9 @@ $filll-c: #a9a9a9;
   background: $track-c;
 
   @if $fill == 1 {
-    .js & {
+    & {
       background: linear-gradient($filll-c, $filll-c)
-      0/ var(--sx) 100% no-repeat $track-c;
+      0 / var(--sx) 100% no-repeat $track-c;
     }
   }
 }
@@ -71,21 +71,18 @@ $filll-c: #a9a9a9;
   &, &::-webkit-slider-thumb {
     -webkit-appearance: none;
   }
-
   --range: calc(var(--max) - var(--min));
-  --ratio: calc((var(--val) - var(--min))/var(--range));
-  --sx: calc(.5*#{$thumb-d} + var(--ratio)*(100% - #{$thumb-d}));
+  --ratio: calc((var(--val) - var(--min)) / var(--range));
+  --sx: calc(.5 * #{$thumb-d} + var(--ratio) * (100% - #{$thumb-d}));
   margin: 0;
   padding: 0;
   width: $track-w;
   max-width: 100%;
   height: $thumb-d;
   background: transparent;
-  font: 1em/1 arial, sans-serif;
+  font: 1em / 1 arial, sans-serif;
 
-  &::-webkit-slider-runnable-track {
-    @include track(1)
-  }
+  &::-webkit-slider-runnable-track { @include track(1) }
   &::-moz-range-track { @include track }
   &::-ms-track { @include track }
 
@@ -93,7 +90,7 @@ $filll-c: #a9a9a9;
   &::-ms-fill-lower { @include fill }
 
   &::-webkit-slider-thumb {
-    margin-top: .5*($track-h - $thumb-d);
+    margin-top: .5 * ($track-h - $thumb-d);
     @include thumb
   }
   &::-moz-range-thumb { @include thumb }


### PR DESCRIPTION
Fixes audio track progress styling on webkit browsers.  Also fixes "dull" point on right of play button in audio player.

Now imports `Source Code Pro` from googlefonts along with `Montserrat`, enabling use in browsers that do not contain the font by default.